### PR TITLE
Use `publish` on the class to prevent forgetting to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ class PaymentProcessor
     # Run code to charge the card...
 
     # Then fire an event
-    PaymentProcessor::ChargeCardEvent.new(amount).publish
+    PaymentProcessor::ChargeCardEvent.publish(amount)
   end
 end
 ```
@@ -61,7 +61,7 @@ Database::QueryEvent.subscribe do |event, duration|
   # Do something with the event and duration
 end
 
-Database::QueryEvent.new.publish do
+Database::QueryEvent.publish do
   # Run a query, run some other code, etc.
 end
 ```
@@ -85,7 +85,7 @@ Database::QueryEvent.subscribe do |event, duration|
   puts event.query
 end
 
-Database::QueryEvent.new(query: "SELECT * FROM users").publish do
+Database::QueryEvent.publish(query: "SELECT * FROM users") do
   # Run a query, run some other code, etc.
 end
 ```

--- a/spec/pulsar_spec.cr
+++ b/spec/pulsar_spec.cr
@@ -6,6 +6,11 @@ end
 class Pulsar::TestTimedEvent < Pulsar::TimedEvent
 end
 
+class Pulsar::EventWithInit < Pulsar::Event
+  def initialize(@something : String)
+  end
+end
+
 describe Pulsar do
   describe ".elapsed_text" do
     it "formats time spans" do
@@ -31,7 +36,18 @@ describe Pulsar do
       event.should be_a(Pulsar::TestEvent)
     end
 
-    Pulsar::TestEvent.new.publish
+    Pulsar::TestEvent.publish
+
+    called.should be_true
+  end
+
+  it "allows publishing with custom args" do
+    called = false
+    Pulsar::EventWithInit.subscribe do |event|
+      called = true
+    end
+
+    Pulsar::EventWithInit.publish(something: "foo")
 
     called.should be_true
   end
@@ -45,7 +61,7 @@ describe Pulsar do
       event.should be_a(Pulsar::TestTimedEvent)
     end
 
-    result = Pulsar::TestTimedEvent.new.publish do
+    result = Pulsar::TestTimedEvent.publish do
       :return_me
     end
 

--- a/src/pulsar/event.cr
+++ b/src/pulsar/event.cr
@@ -25,7 +25,32 @@ abstract class Pulsar::Event
   # ```crystal
   # MyEvent.new.publish
   # ```
-  def publish
+  #
+  # ### Passing arguments to initialize
+  #
+  # If your event defines an `initialize` and requires arguments, you can
+  # pass those arguments to `publish`.
+  #
+  # For example if you had the event:
+  #
+  # ```crystal
+  # class MyEvent < Pulsar::Event
+  #   def initialize(custom_argument : String)
+  #   end
+  # end
+  # ```
+  #
+  # You would pass the arguments to `publish` and they will be used to
+  # initialize the event:
+  #
+  # ```crystal
+  # MyEvent.publish(custom_argument: "This is my custom event argument")
+  # ```
+  def self.publish(*args, **named_args)
+    new(*args, **named_args).publish
+  end
+
+  protected def publish
     self.class.subscribers.each do |s|
       s.call(self)
     end

--- a/src/pulsar/timed_event.cr
+++ b/src/pulsar/timed_event.cr
@@ -34,7 +34,36 @@ abstract class Pulsar::TimedEvent
   # ```
   #
   # The `publish` method returns the result of the block.
-  def publish
+  #
+  # ### Passing arguments to initialize
+  #
+  # If your event defines an `initialize` and requires arguments, you can
+  # pass those arguments to `publish`.
+  #
+  # For example if you had the event:
+  #
+  # ```crystal
+  # class MyEvent < Pulsar::TimedEvent
+  #   def initialize(custom_argument : String)
+  #   end
+  # end
+  # ```
+  #
+  # You would pass the arguments to `publish` and they will be used to
+  # initialize the event:
+  #
+  # ```crystal
+  # MyEvent.publish(custom_argument: "This is my custom event argument") do
+  #   # ...run some code
+  # end
+  # ```
+  def self.publish(*args, **named_args)
+    new(*args, **named_args).publish do
+      yield
+    end
+  end
+
+  protected def publish
     start = Time.monotonic
     result = yield
     duration = Time.monotonic - start


### PR DESCRIPTION
It was easy to initialize an event and forget to publish it. This makes
it much easier because it encourages users to use `publish` directly.