### PR TITLE
Add automatic GitHub Pages documentation deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,34 +2,36 @@ name: Crystal CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: "*"
 
 jobs:
   check_format:
     runs-on: ubuntu-latest
-    
+
     container:
       image: crystallang/crystal
-      
+
     steps:
       - uses: actions/checkout@v1
-      - name: Install shards
-        run: shards install
       - name: Format
         run: crystal tool format --check
-     
-  build:
 
+  build:
     runs-on: ubuntu-latest
 
     container:
       image: crystallang/crystal
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install shards
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - uses: actions/checkout@v2
+      - name: Install shards
+        run: shards install
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-crystal
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: "Install shards"
+        run: shards install
+      - name: "Generate docs"
+        run: crystal docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pulsar
 
+[![API Documentation Website](https://img.shields.io/website?down_color=red&down_message=Offline&label=API%20Documentation&up_message=Online&url=https%3A%2F%2Fluckyframework.github.io%2Fpulsar%2F)](https://luckyframework.github.io/pulsar)
+
 Pulsar is a simple Crystal library for publishing and subscribing to events.
 It also has timing information for metrics. So what does that mean in
 practice?
@@ -176,7 +178,6 @@ puts "I just took 5 seconds to print!"
 
 Oops. To get around this you can spawn a new fiber:
 
-
 ```crystal
 MyEvent.subscribe do |event|
   # Now the `sleep` will run in a new Fiber and will not block this one
@@ -197,7 +198,7 @@ You could also use a background job library like https://github.com/robacarp/mos
 
 Be aware that running things in a Fiber will lose the current Fiber's context. This is
 important for logging since `Log.context` only works for the current Fiber.
-So if you plan to log using the built-in Logger, you likely *do not* want to
+So if you plan to log using the built-in Logger, you likely _do not_ want to
 spawn a new fiber. It is fast enough to just log like normal.
 
 ## Contributing


### PR DESCRIPTION
This is part of a series of PRs to get all of our Lucky repositories auto-deploying API documentation to GitHub pages. Having these accessible will assist with the new "Learn" section on the website.

This PR contains the following elements:
- Slightly refactor the existing CI, and rename to be consistent with other repos
- Add the GitHub Action to build documentation into the `gh-pages` branch
- Add a badge to the README linking to the API documentation