### PR TITLE
Cleaning up for Crystal 1.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         crystal_version:
           - 0.35.1
+          - 0.36.1
           - 1.0.0
         experimental:
           - false
@@ -31,6 +32,7 @@ jobs:
       matrix:
         crystal_version:
           - 0.35.1
+          - 0.36.1
           - 1.0.0
         experimental:
           - false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Crystal CI
+name: Pulsar CI
 
 on:
   push:
@@ -8,10 +8,17 @@ on:
 
 jobs:
   check_format:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal_version:
+          - 0.35.1
+          - 1.0.0
+        experimental:
+          - false
     runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal
+    continue-on-error: ${{ matrix.experimental }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
 
     steps:
       - uses: actions/checkout@v1
@@ -19,10 +26,17 @@ jobs:
         run: crystal tool format --check
 
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal_version:
+          - 0.35.1
+          - 1.0.0
+        experimental:
+          - false
     runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal
+    continue-on-error: ${{ matrix.experimental }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-
-# Uncomment the following if you'd like Travis to run specs and check code formatting
-# script:
-#   - crystal spec
-#   - crystal tool format --check

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.2.1
 authors:
   - Paul Smith <@paulcsmith>
 
-crystal: 0.35.1
+crystal: ">= 0.35.1, < 2.0.0"
 
 license: MIT

--- a/src/pulsar.cr
+++ b/src/pulsar.cr
@@ -11,7 +11,7 @@ module Pulsar
   # spec is run. You can access an Event's log using the `logged_events` class
   # method
   #
-  # ```crystal
+  # ```
   # MyEvent.publish
   #
   # MyEvent.logged_events.size.should eq(1)
@@ -44,7 +44,7 @@ module Pulsar
 
   # Will return the time taken (`Time::Span`) as a human readable `String`.
   #
-  # ```crystal
+  # ```
   # Database::QueryEvent.subscribe do |event, duration|
   #   puts Pulsar.elaspted_text(duration) # "2.3ms"
   # end

--- a/src/pulsar/event.cr
+++ b/src/pulsar/event.cr
@@ -9,7 +9,7 @@ abstract class Pulsar::Event < Pulsar::BaseEvent
 
   # Subscribe to events
   #
-  # ```crystal
+  # ```
   # MyEvent.subscribe do |event|
   #   puts event.name # "MyEvent"
   # end
@@ -22,7 +22,7 @@ abstract class Pulsar::Event < Pulsar::BaseEvent
 
   # Publishes the event to all subscribers.
   #
-  # ```crystal
+  # ```
   # MyEvent.publish
   # ```
   #
@@ -33,7 +33,7 @@ abstract class Pulsar::Event < Pulsar::BaseEvent
   #
   # For example if you had the event:
   #
-  # ```crystal
+  # ```
   # class MyEvent < Pulsar::Event
   #   def initialize(custom_argument : String)
   #   end
@@ -43,7 +43,7 @@ abstract class Pulsar::Event < Pulsar::BaseEvent
   # You would pass the arguments to `publish` and they will be used to
   # initialize the event:
   #
-  # ```crystal
+  # ```
   # MyEvent.publish(custom_argument: "This is my custom event argument")
   # ```
   def self.publish(*args_, **named_args_)

--- a/src/pulsar/timed_event.cr
+++ b/src/pulsar/timed_event.cr
@@ -9,7 +9,7 @@ abstract class Pulsar::TimedEvent < Pulsar::BaseEvent
 
   # Subscribe to events
   #
-  # ```crystal
+  # ```
   # MyEvent.subscribe do |event, duration|
   #   # Do something with the event and duration
   # end
@@ -27,7 +27,7 @@ abstract class Pulsar::TimedEvent < Pulsar::BaseEvent
   # Similar to `Pulsar::Event#publish` but measures and publishes the time
   # it takes to run the block.
   #
-  # ```crystal
+  # ```
   # MyEvent.publish do
   #   # Run some code
   # end
@@ -42,7 +42,7 @@ abstract class Pulsar::TimedEvent < Pulsar::BaseEvent
   #
   # For example if you had the event:
   #
-  # ```crystal
+  # ```
   # class MyEvent < Pulsar::TimedEvent
   #   def initialize(custom_argument : String)
   #   end
@@ -52,7 +52,7 @@ abstract class Pulsar::TimedEvent < Pulsar::BaseEvent
   # You would pass the arguments to `publish` and they will be used to
   # initialize the event:
   #
-  # ```crystal
+  # ```
   # MyEvent.publish(custom_argument: "This is my custom event argument") do
   #   # ...run some code
   # end


### PR DESCRIPTION
I ran the formatter and specs locally using Crystal 1.0. Everything looks good. Since this shard also runs on Crystal 0.35.1+, I figure we can update the CI to include a matrix of the lowest version of Crystal we support, and then the latest version. 

@stephendolan I took the matrix deal from the PR you did on sitemapper.